### PR TITLE
Patch null pointer exception in particle.dart

### DIFF
--- a/lib/src/particle.dart
+++ b/lib/src/particle.dart
@@ -38,7 +38,7 @@ class ParticleSystem extends ChangeNotifier {
 
   ParticleSystemStatus _particleSystemStatus;
 
-  List<Particle> _particles;
+  List<Particle> _particles = [];
 
   /// A frequency between 0 and 1 to determine how often the emitter
   /// should emit new particles.


### PR DESCRIPTION
Inits `_particles` with an empty list, for when `_generateParticles()` fails to be executed by chance, NPE will be thrown on line 99 in `_particle.dart`.