### PR TITLE
Enhancement/assert non positive durations

### DIFF
--- a/lib/src/confetti.dart
+++ b/lib/src/confetti.dart
@@ -317,7 +317,9 @@ enum ConfettiControllerState {
 
 class ConfettiController extends ChangeNotifier {
   ConfettiController({this.duration = const Duration(seconds: 30)})
-      : assert(duration != null);
+      : assert(duration != null &&
+            !duration.isNegative &&
+            duration.inMicroseconds > 0);
 
   Duration duration;
 

--- a/lib/src/confetti.dart
+++ b/lib/src/confetti.dart
@@ -224,7 +224,6 @@ class _ConfettiWidgetState extends State<ConfettiWidget>
 
   @override
   void dispose() {
-    print('dispose called');
     _animController.dispose();
     widget.confettiController.removeListener(_handleChange);
     _particleSystem.removeListener(_particleSystemListener);

--- a/test/confetti_test.dart
+++ b/test/confetti_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:confetti/confetti.dart';
+
+void main() {
+  group('ConfettiController', () {
+    test('throws assertion error when `duration` is not positive', () {
+      expect(() => ConfettiController(duration: const Duration(days: -20)),
+          throwsAssertionError);
+
+      expect(() => ConfettiController(duration: const Duration(seconds: 0)),
+          throwsAssertionError);
+
+      expect(
+          () => ConfettiController(duration: const Duration(milliseconds: 0)),
+          throwsAssertionError);
+
+      expect(
+          () => ConfettiController(duration: const Duration(microseconds: 0)),
+          throwsAssertionError);
+    });
+  });
+}


### PR DESCRIPTION
As discussed in #19, this is a small PR to assert that `duration` is positive. Also removes an unwanted `print` from `dispose()` (I wondered why I was seeing "dispose called"). 👍 