### PR TITLE
Fix: ConfettiControllerState.stopped event not fired in ConfettiController listener

### DIFF
--- a/lib/confetti.dart
+++ b/lib/confetti.dart
@@ -2,3 +2,4 @@ library confetti;
 
 export 'src/confetti.dart';
 export 'src/enums/blast_directionality.dart';
+export 'src/enums/confetti_controller_state.dart';

--- a/lib/src/confetti.dart
+++ b/lib/src/confetti.dart
@@ -215,6 +215,7 @@ class _ConfettiWidgetState extends State<ConfettiWidget>
 
   void _stopAnimation() {
     _animController.stop();
+    widget.confettiController.stop();
   }
 
   void _continueAnimation() {


### PR DESCRIPTION
These changes fix the problem with the animation's `stopped` event not being fired.
Additionally, they allow to compare the confetti controller's state with `ConfettiControllerState` values.
E.g.
```dart
    confettiController.addListener(() {
      if (confettiController.state == ConfettiControllerState.stopped)
        print("Confetti animation stopped!");
    });
```

Closes #30.