### PR TITLE
Don't notify on dispose to avoid exception

### DIFF
--- a/lib/src/confetti.dart
+++ b/lib/src/confetti.dart
@@ -275,7 +275,7 @@ class _ConfettiWidgetState extends State<ConfettiWidget>
 
   @override
   void dispose() {
-    widget.confettiController.stop();
+    widget.confettiController.stop(notify: false);
     _animController.dispose();
     widget.confettiController.removeListener(_handleChange);
     _particleSystem.removeListener(_particleSystemListener);
@@ -365,8 +365,10 @@ class ConfettiController extends ChangeNotifier {
     notifyListeners();
   }
 
-  void stop() {
+  void stop({bool notify = true}) {
     _state = ConfettiControllerState.stopped;
-    notifyListeners();
+    if (notify) {
+      notifyListeners();
+    }
   }
 }


### PR DESCRIPTION
I was encountering the following exception everytime a `Confetti` widget was disposed:

```
════════ Exception caught by foundation library ════════════════════════════════════════════════════
The following assertion was thrown while dispatching notifications for ConfettiController:
setState() or markNeedsBuild() called when widget tree was locked.

This _InheritedProviderScope<ConfettiController> widget cannot be marked as needing to build because the framework is locked.
The widget on which setState() or markNeedsBuild() was called was: _InheritedProviderScope<ConfettiController>
  value: Instance of 'ConfettiController'
  listening to value
When the exception was thrown, this was the stack: 
#0      Element.markNeedsBuild.<anonymous closure> (package:flutter/src/widgets/framework.dart:4297:9)
#1      Element.markNeedsBuild (package:flutter/src/widgets/framework.dart:4307:6)
#2      _InheritedProviderScopeElement.markNeedsNotifyDependents (package:provider/src/inherited_provider.dart:496:5)
#3      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:226:25)
#4      ConfettiController.stop (package:confetti/src/confetti.dart:371:7)
...
The ConfettiController sending notification was: Instance of 'ConfettiController'
════════════════════════════════════════════════════════════════════════════════════════════════════
```

It was being caught by the framework, but started to clog up my logs. Simply avoiding a call to `notifyListeners` during `dispose()` fixes the issue.