### PR TITLE
Invoke the overridden method.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,6 +33,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void initState() {
+    super.initState();
     _controllerCenter =
         ConfettiController(duration: const Duration(seconds: 10));
     _controllerCenterRight =


### PR DESCRIPTION
Fixed: This method overrides a method annotated as '@mustCallSuper' in 'State', but doesn't invoke the overridden method.