### PR TITLE
fix: confetti disappearing in device_preview

### DIFF
--- a/lib/src/confetti.dart
+++ b/lib/src/confetti.dart
@@ -150,14 +150,9 @@ class ConfettiWidget extends StatefulWidget {
 
 class _ConfettiWidgetState extends State<ConfettiWidget>
     with SingleTickerProviderStateMixin {
-  final GlobalKey _particleSystemKey = GlobalKey();
-
   late AnimationController _animController;
   late Animation<double> _animation;
   late ParticleSystem _particleSystem;
-
-  /// Keeps track of emition position on screen layout changes
-  late Offset _emitterPosition;
 
   /// Keeps track of the screen size on layout changes.
   ///
@@ -275,10 +270,8 @@ class _ConfettiWidgetState extends State<ConfettiWidget>
   }
 
   void _startAnimation() {
-    // Make sure widgets are built before setting screen size and position
     if (mounted) {
       _setScreenSize();
-      _setEmitterPosition();
       _animController.forward(from: 0);
     }
   }
@@ -297,21 +290,6 @@ class _ConfettiWidgetState extends State<ConfettiWidget>
     _particleSystem.screenSize = _screenSize;
   }
 
-  void _setEmitterPosition() {
-    _emitterPosition = _getContainerPosition();
-    _particleSystem.particleSystemPosition = _emitterPosition;
-  }
-
-  Offset _getContainerPosition() {
-    if (mounted) {
-      final containerRenderBox =
-          _particleSystemKey.currentContext?.findRenderObject() as RenderBox?;
-      return containerRenderBox?.localToGlobal(Offset.zero) ?? Offset.zero;
-    } else {
-      return Offset.zero;
-    }
-  }
-
   Size _getScreenSize() {
     if (mounted) {
       try {
@@ -327,19 +305,9 @@ class _ConfettiWidgetState extends State<ConfettiWidget>
     }
   }
 
-  /// On layout change update the position of the emitter
-  /// and the screen size.
-  ///
-  /// Only update the emitter if it has already been set, to avoid RenderObject
-  /// issues.
-  ///
-  /// The emitter position is first set in the `addPostFrameCallback`
-  /// in [initState].
   void _updatePositionAndSize() {
-    // TODO: improve this
     if (_getScreenSize() != _screenSize) {
       _setScreenSize();
-      _setEmitterPosition();
     }
   }
 
@@ -354,7 +322,6 @@ class _ConfettiWidgetState extends State<ConfettiWidget>
 
         return RepaintBoundary(
           child: CustomPaint(
-            key: _particleSystemKey,
             willChange: true,
             foregroundPainter: ParticlePainter(
               _animController,

--- a/lib/src/particle.dart
+++ b/lib/src/particle.dart
@@ -86,7 +86,6 @@ class ParticleSystem extends ChangeNotifier {
   final double _particleDrag;
   final Path Function(Size size)? _createParticlePath;
 
-  Offset _particleSystemPosition = Offset.zero;
   Size _screenSize = Size.zero;
 
   late double _bottomBorder;
@@ -94,10 +93,6 @@ class ParticleSystem extends ChangeNotifier {
   late double _leftBorder;
 
   final Random _rand;
-
-  set particleSystemPosition(Offset position) {
-    _particleSystemPosition = position;
-  }
 
   set screenSize(Size size) {
     _screenSize = size;
@@ -208,10 +203,12 @@ class ParticleSystem extends ChangeNotifier {
   }
 
   bool _isOutsideOfBorder(Offset particleLocation) {
-    final globalParticlePosition = particleLocation + _particleSystemPosition;
-    return (globalParticlePosition.dy >= _bottomBorder) ||
-        (globalParticlePosition.dx >= _rightBorder) ||
-        (globalParticlePosition.dx <= _leftBorder);
+    // Cull in local/canvas space only. Mixing in global [localToGlobal] and
+    // [MediaQuery] sizes breaks when the subtree is offset or scaled (e.g.
+    // [DevicePreview]).
+    return (particleLocation.dy >= _bottomBorder) ||
+        (particleLocation.dx >= _rightBorder) ||
+        (particleLocation.dx <= _leftBorder);
   }
 
   void _addParticles(List<Particle> particles, {int number = 1}) {


### PR DESCRIPTION
## Why

I was working on integrating `confetti` into an app with `device_preview`. Currently, it seems that it doesn't show confetti in the right place. This seems to be a _position_ issue.

The confetti layer was using two different ways to measure "where a particle is": local positions and global screen position. They don't match when the app is drawn in a special container (for example, `device_preview`), so the engine thought every particle was already off-screen and removed it right away. Culling is now done in the same local space the particles are drawn in, and the old global-position path was removed because it’s no longer needed.

Here's a video that showcases the bug:

https://github.com/user-attachments/assets/a4e3e28d-0d0e-4132-a1e1-8661431e54ff

I know the [last commit](https://github.com/funwithflutter/flutter_confetti/commit/736dd344a4f6a9d38a45d937964544e1bb741c7e) is from `Sep 28, 2024`, which means this may not be reviewed. That said, leaving this _just in case_ anyone runs into the issue. 😄 

## How I Tested

Add `device_preview`.

- [x] With `device_preview` turned off, see the confetti. Resize the window, and see that confetti still shoots out of the right place.

https://github.com/user-attachments/assets/03886f68-c781-428d-ade0-bb1305a9633d

- [x] Using `device_preview`, see the confetti. Resize the window, and see that confetti still shoots out of the right place.

https://github.com/user-attachments/assets/51ec4add-3f76-4034-880b-159043d6986d
